### PR TITLE
Adding assert() and explainStr() to match clojure.spec missing behaviour

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,23 @@ export function explainData(spec, value) {
   })
 }
 
+const problemStr = function (problem, value) {
+  return `${problem.via.join(" → ")}: ${problem.predicateName} failed for ${getIn(value, problem.path)} at [${problem.path.join(", ")}].`
+};
+
 export function explain(spec, value) {
   explainData(spec, value)
-    .forEach(problem => console.log(`${problem.via.join(" → ")}: ${problem.predicateName} failed for ${getIn(value, problem.path)} at [${problem.path.join(", ")}].`))
+    .forEach(problem => console.log(problemStr(problem, value)))
+}
+
+export function explainStr(spec, value) {
+  return explainData(spec, value)
+    .map(problem => problemStr(problem, value))
+    .join("\n")
+}
+
+export function assert(spec, value) {
+  if (!util.valid(spec, value)) {
+    throw new Error(explainStr(spec, value))
+  }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,15 @@
+import {expect} from 'chai'
+import {assert} from '../index'
+import {number} from '../lib/predicates'
+
+describe("index", () => {
+  describe("assert", () => {
+    it("does not throw an Error when valid", () => {
+      expect(() => assert(number, 1)).to.not.throw(Error)
+    })
+
+    it("throws an Error when invalid", () => {
+      expect(() => assert(number, "string")).to.throw(Error, "isNumber")
+    })
+  })
+})


### PR DESCRIPTION
Fix for https://github.com/prayerslayer/js.spec/issues/15

Tested with `yarn test`.
It updated checked-in file `dist/js.spec.bundle.js` but I doubt you want that change in a PR.