### PR TITLE
Match Spec.explain() with implementations

### DIFF
--- a/lib/spec/spec.js
+++ b/lib/spec/spec.js
@@ -14,7 +14,7 @@ export default class Spec {
     throw new Error(`Implement in subclass: unform(${conformed})`);
   }
 
-  explain(value) {
+  explain(path, via, value) {
     throw new Error(`Implement in subclass: explain(${value})`);
   }
 }


### PR DESCRIPTION
All of the implementations of Spec classes use a different explain() signature than the base class. Fix base class to match.