### PR TITLE
Package new types correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
     "url": "https://github.com/prayerslayer/js.spec/issues"
   },
   "homepage": "https://github.com/prayerslayer/js.spec#readme",
+  "files": [
+    "index.js",
+    "lib/*",
+    "dist/*",
+    "types/*"
+  ],
   "devDependencies": {
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "yarn run build",
     "test": "yarn run lint && yarn run test-ts && mocha --recursive --compilers js:babel-register test",
     "test:watch": "mocha --recursive --reporter=min --watch --compilers js:babel-register test",
-    "test-ts": "./node_modules/.bin/tsc --noImplicitAny --noEmit types/types-test.ts",
+    "test-ts": "./node_modules/.bin/tsc --noImplicitAny --noEmit test/types/types-test.ts",
     "coverage": "babel-node ./node_modules/.bin/babel-istanbul cover ./node_modules/.bin/_mocha -- test --recursive",
     "coveralls": "yarn run coverage && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
     "autobuild": "./node_modules/.bin/nodemon -i 'dist/' -e 'js' -x 'yarn run build'",

--- a/test/types/types-test.ts
+++ b/test/types/types-test.ts
@@ -1,4 +1,4 @@
-import * as S from "./index";
+import * as S from "../../types/index";
 
 const spec: S.Spec = S.spec.predicate("test spec", S.spec.bool);
 const c: symbol = spec.conform("water");


### PR DESCRIPTION
This does two things:

  * move the test/types-test.ts file in the test folder
  * use "files" in package.json

With this two addition we will deploy a cleaner package to npm.