### PR TITLE
Fix documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For a quick usage example see [example.js](example.js). Otherwise please refer t
 
 # Documentation
 
-[http://js-spec.online/](http://js-spec.online/)
+[https://prayerslayer.gitbooks.io/js-spec/content/](https://prayerslayer.gitbooks.io/js-spec/content/)
 
 # Installation
 


### PR DESCRIPTION
Changed http://js-spec.online/ to https://prayerslayer.gitbooks.io/js-spec/content/